### PR TITLE
Binary hack: Fix extra stage relocking

### DIFF
--- a/base_tsa/th11.v1.00a.js
+++ b/base_tsa/th11.v1.00a.js
@@ -43,6 +43,10 @@
 			"addr": "Rx35233",
 			"code": "85c0 7412 51 d980c4030000 d91c24 e88a3c0200 d95e30 33c0 5e c20400",
 			"expected": "51 d980c4030000 d91c24 e88e3c0200 d95e30 33c0 5e c20400 cccccccc"
+		},
+		"fix_extra_stage_relocking": {
+			"addr": "Rxede8",
+			"code": "08 94 01 eadd0200"
 		}
 	},
 	"breakpoints": {


### PR DESCRIPTION
Fixes a bug that causes access to the extra stage to get relocked after completing the game on easy even when it had already been unlocked. This is acchieved by replacing a mov operation with an or operation.