### PR TITLE
Add binhacks for centering PCB and IN in-game ASCII strings

### DIFF
--- a/base_tsa/th07.js
+++ b/base_tsa/th07.js
@@ -42,7 +42,15 @@
 		"bosstitle_line_order#2": {
 			"title": "Render the two boss title lines in the opposite order, #2: Title",
 			"code": "f0040200"
-		}
+		},
+		"ascii_patch_1": {
+			"title": "Hook ZUN's variadic ASCII printing function to perform a bunch of intricate hacks in C++ code (#1: Call, and write the inner function)",
+			"code": "50 ff7510 ff750c e80b000000 83c00f 50 e8[ascii_vpatchf] eb1d | 8b0424 c3 | ff74240c ff74240c 8b4c240c 90"
+		},
+		"ascii_patch_2": {
+			"title": "Hook ZUN's variadic ASCII printing function to perform a bunch of intricate hacks in C++ code (#2: Return from the inner function)",
+			"code": "c3 909090909090"
+		},
 	},
 	"title": "東方妖々夢　～ Perfect Cherry Blossom",
 	"url_update": "http://www16.big.or.jp/~zun/html/th07_update.html",
@@ -127,6 +135,10 @@
 			},
 			"groups": [["0x702", "0x703"]],
 			"cavesize": 7
+		},
+		"ascii_params": {
+			".Scale": "0x74c4",
+			"CharWidth": 14.0
 		}
 	},
 	"tlnotes": {

--- a/base_tsa/th07.v1.00b.js
+++ b/base_tsa/th07.v1.00b.js
@@ -83,7 +83,9 @@
 		},
 		"reacquire_input": {
 			"addr": "Rx30f03"
-		}
+		},
+		"ascii_patch_1": { "addr": "Rx206c" },
+		"ascii_patch_2": { "addr": "Rx2099" }
 	},
 	"breakpoints": {
 		"file_name": {
@@ -145,6 +147,10 @@
 			"TextureSlots": "[0x4b9e44]+0x282ac",
 			"SpriteSpecs": "[0x4b9e44]+0x60",
 			"SpriteScripts": "[0x4b9e44]+0x28ef0"
+		},
+		"ascii_params": {
+			"addr": "Rx38c5f",
+			"ClassPtr": "0x134ce18"
 		},
 		"th06_screenshot": {
 			"pD3DDevice": "[0x575958]",

--- a/base_tsa/th08.js
+++ b/base_tsa/th08.js
@@ -65,7 +65,15 @@
 		"spell_ascii_numbers_2": {
 			"code": "90",
 			"title": "Replace shift-jis numbers with ASCII numbers in spell practice (part 2)"
-		}
+		},
+		"ascii_patch_1": {
+			"title": "Hook ZUN's variadic ASCII printing function to perform a bunch of intricate hacks in C++ code (#1: Call, and write the inner function)",
+			"code": "50 ff7510 ff750c e80b000000 83c00f 50 e8[ascii_vpatchf] eb1d | 8b0424 c3 | ff74240c ff74240c 8b4c240c 90"
+		},
+		"ascii_patch_2": {
+			"title": "Hook ZUN's variadic ASCII printing function to perform a bunch of intricate hacks in C++ code (#2: Return from the inner function)",
+			"code": "c3 909090909090"
+		},
 	},
 	"title": "東方永夜抄　～ Imperishable Night",
 	"url_update": "http://www16.big.or.jp/~zun/html/th08dl.html",
@@ -176,6 +184,10 @@
 			"str": "edi",
 			"format_id": "Music Room Numbered Title",
 			"cavesize": "5"
+		},
+		"ascii_params": {
+			".Scale": "0x826c",
+			"CharWidth": 13.0
 		}
 	},
 	"tlnotes": {

--- a/base_tsa/th08.v1.00d.js
+++ b/base_tsa/th08.v1.00d.js
@@ -96,7 +96,9 @@
 			"addr": "0x44869D",
 			"code": "83C4 08 // 8B4D 08 // E8 [codecave:TH8ScorefileFixer_FixVRSM] // 8945 FC // 2B45 F0 // 2945 F4",
 			"expected": "59 // 59 // 40 // 8945 FC // 8B45 FC // 2B45 F0 // 8B4D F4 // 2BC8 // 894D F4"
-		}
+		},
+		"ascii_patch_1": { "addr": "Rx2a3c" },
+		"ascii_patch_2": { "addr": "Rx2a69" }
 	},
 	"breakpoints": {
 		"file_name": {
@@ -155,6 +157,10 @@
 		},
 		"music_cmt": {
 			"addr": "0x448f26"
-		}
+		},
+		"ascii_params": {
+			"addr": "Rx465B5",
+			"ClassPtr": "0x4cce20"
+		},
 	}
 }


### PR DESCRIPTION
Adds binhacks for executing ascii_vpatch ([to which I added PCB/IN functionality to here](https://github.com/thpatch/thcrap/pull/236)) in PCB and IN to properly center translated in-game ASCII strings (such as "Full Power Mode!", "Supernatural Border!!").