### PR TITLE
base_tsa: Fix the display of musicroom's comments.

### DIFF
--- a/base_tsa/th07.js
+++ b/base_tsa/th07.js
@@ -106,7 +106,7 @@
 		},
 		"music_cmt": {
 			"str": "eax",
-			"format_id": "Music Room Note Title",
+			"format_id": "Music Room Numbered Title",
 			"cavesize": "6"
 		},
 		"textimage_set": {


### PR DESCRIPTION
The BGM title displayed as "♪ %s", and the correct form is "No.%2d %s".