### PR TITLE
Stage Practice string

### DIFF
--- a/base_tsa/th06/stringlocs.v1.02h.js
+++ b/base_tsa/th06/stringlocs.v1.02h.js
@@ -69,5 +69,6 @@
 	"Rx1c145": "th06_replay_0",
 	"Rx6bc20": "th06_replay_format",
 	"Rx6c3cc": "th06_replay_user_find",
-	"Rx6af94": "th06_scorefile_fn"
+	"Rx6af94": "th06_scorefile_fn",
+	"Rx6c4c8": "th06_practice_format"
 }


### PR DESCRIPTION
Seems like EoSD prints this string a bit differently.
Also, the original displays only nine digits of the score, like per usual.