### PR TITLE
th175: Fix some IDs for nut mappings and add missing mappings

### DIFF
--- a/base_tasofro/th175/data/script/init/200_sound.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/init/200_sound.v1.15.nut.map
@@ -1,0 +1,4 @@
+{
+    "/Functions/1/Literals/16": "BGM Get 1",
+    "/Functions/1/Literals/18": "Get 2",
+}

--- a/base_tasofro/th175/data/script/lib/session_data.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/lib/session_data.v1.15.nut.map
@@ -1,0 +1,3 @@
+{
+    "/Functions/11/Literals/15": "Release Gonyoku MODE"
+}

--- a/base_tasofro/th175/data/script/lib/trophy.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/lib/trophy.v1.15.nut.map
@@ -1,0 +1,4 @@
+{
+    "/Functions/20/Literals/15": "Trophy Get 1",
+    "/Functions/20/Literals/16": "Get 2",
+}

--- a/base_tasofro/th175/data/script/scene/config.v1.01.nut.map
+++ b/base_tasofro/th175/data/script/scene/config.v1.01.nut.map
@@ -8,5 +8,5 @@
     "/Functions/6/Literals/13": "Config Graze",
     "/Functions/6/Literals/14": "Config Attack",
     "/Functions/6/Literals/15": "Config Absorb",
-    "/Functions/6/Literals/40": "Config Button Selection",
+    "/Functions/6/Literals/40": "Config Button Selection 2",
 }

--- a/base_tasofro/th175/data/script/scene/config.v1.14.nut.map
+++ b/base_tasofro/th175/data/script/scene/config.v1.14.nut.map
@@ -11,5 +11,5 @@
     "/Functions/7/Literals/13": "Config Graze",
     "/Functions/7/Literals/14": "Config Attack",
     "/Functions/7/Literals/15": "Config Absorb",
-    "/Functions/7/Literals/40": "Config Button Selection",
+    "/Functions/7/Literals/40": "Config Button Selection 2",
 }

--- a/base_tasofro/th175/data/script/scene/config.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/scene/config.v1.15.nut.map
@@ -1,4 +1,8 @@
 {
+    "/Functions/2/Literals/41": "Config Graze Text",
+    "/Functions/2/Literals/43": "Config Attack Text",
+    "/Functions/2/Literals/44": "Config Absorb Text",
+    "/Functions/2/Literals/47": "Config Complete",
     "/Functions/5/Literals/3": "Config Choose Option",
     "/Functions/5/Literals/4": "Config Change Value",
     "/Functions/5/Literals/5": "Config OK",
@@ -8,8 +12,13 @@
     "/Functions/6/Literals/4": "Config OK",
     "/Functions/6/Literals/17": "Config Complete",
     "/Functions/7/Literals/4": "Config Keys",
+    "/Functions/7/Literals/9": "Config Up",
+    "/Functions/7/Literals/10": "Config Down",
+    "/Functions/7/Literals/11": "Config Left",
+    "/Functions/7/Literals/12": "Config Right",
     "/Functions/7/Literals/13": "Config Graze",
     "/Functions/7/Literals/14": "Config Attack",
     "/Functions/7/Literals/15": "Config Absorb",
+    "/Functions/7/Literals/16": "Config Pause",
     "/Functions/7/Literals/40": "Config Button Selection 2",
 }

--- a/base_tasofro/th175/data/script/scene/config.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/scene/config.v1.15.nut.map
@@ -11,5 +11,5 @@
     "/Functions/7/Literals/13": "Config Graze",
     "/Functions/7/Literals/14": "Config Attack",
     "/Functions/7/Literals/15": "Config Absorb",
-    "/Functions/7/Literals/40": "Config Button Selection",
+    "/Functions/7/Literals/40": "Config Button Selection 2",
 }

--- a/base_tasofro/th175/data/script/scene/stage_result.v1.01.nut.map
+++ b/base_tasofro/th175/data/script/scene/stage_result.v1.01.nut.map
@@ -1,6 +1,6 @@
 {
     "/Functions/2/Literals/34": "Stage Result Proceed Button",
-    "/Functions/2/Literals/40": "Stage Result Give up prompt 1",
+    "/Functions/2/Literals/40": "Stage Result Give up prompt",
     "/Functions/2/Literals/42": "Stage Result Oil statistics",
     "/Functions/2/Literals/43": "Stage Result Blood statistics",
     "/Functions/2/Literals/44": "Stage Result Water statistics",

--- a/base_tasofro/th175/data/script/scene/superimpose.v1.15.nut.map
+++ b/base_tasofro/th175/data/script/scene/superimpose.v1.15.nut.map
@@ -1,0 +1,3 @@
+{
+    "/Functions/4/Literals/5": "Hint Close"
+}


### PR DESCRIPTION
The missing mappings were sourced from the [Th175/Nut strings](https://www.thpatch.net/wiki/Th175/Nut_strings) page on TPC.
I did not add the missing mappings to the mappings for older versions, because I do not have access to the nut files from those versions and thus can't verify that the mappings would be identical to the mappings for v1.15.